### PR TITLE
位置情報に周辺の店情報を返信する

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,13 +29,10 @@ class WebhookController < ApplicationController
             text: event.message['text']
           }
           client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Location
-          user_lat = event.message.address
-          user_lon = event.message.longitude
-          message = {
-            type: 'text',
-            text: "位置情報を受け取りました。緯度: #{user_lat}, 経度: #{user_lon}"
-          }
+        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
+          response = client.get_message_content(event.message['id'])
+          tf = Tempfile.open("content")
+          tf.write(response.body)
         end
       end
     }

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,10 +29,13 @@ class WebhookController < ApplicationController
             text: event.message['text']
           }
           client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
+        when Line::Bot::Event::MessageType::Location
+          user_lat = event.message.address
+          user_lon = event.message.longitude
+          message = {
+            type: 'text',
+            text: "位置情報を受け取りました。緯度: #{user_lat}, 経度: #{user_lon}"
+          }
         end
       end
     }

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -10,6 +10,33 @@ class WebhookController < ApplicationController
     }
   end
 
+  def search_shop(lat, lng)
+    hotpepper_api = "http://webservice.recruit.co.jp/hotpepper/gourmet/v1/"
+    uri = URI.parse(hotpepper_api)
+    http = Net::HTTP.new(uri.host, uri.port) 
+    uri.query = URI.encode_www_form({
+        key: ENV["API_KEY"],
+        lat: lat,
+        lng: lng,
+        range: 3,
+        genre: "G001,G002",
+        budget: "B002,B003",
+        order: 4,
+        format: 'json'
+    })
+    p uri
+    request = Net::HTTP::Get.new(uri)
+    response = http.request(request)
+    puts 'END !!'
+
+    if response.code == '200'
+        data = JSON.parse(response.body)
+        return data["results"]["shop"].map { |shop| shop["name"] }
+    else
+        return "リクエストが失敗しました。ステータスコード: #{response.code}"
+    end
+  end
+
   def callback
     body = request.body.read
 
@@ -30,9 +57,10 @@ class WebhookController < ApplicationController
           }
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Location
+          res_text = search_shop(event.message['latitude'], event.message['longitude'])
           message = {
             type: 'text',
-            text: "位置情報を受信しました\n緯度: #{event.message['latitude']}\n経度: #{event.message['longitude']}"
+            text: res_text.to_s
           }
           client.reply_message(event['replyToken'], message)
         end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -29,10 +29,12 @@ class WebhookController < ApplicationController
             text: event.message['text']
           }
           client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
+        when Line::Bot::Event::MessageType::Location
+          message = {
+            type: 'text',
+            text: "位置情報を受信しました\n緯度: #{event.message['latitude']}\n経度: #{event.message['longitude']}"
+          }
+          client.reply_message(event['replyToken'], message)
         end
       end
     }


### PR DESCRIPTION
## 実装の背景・目的
<!--レビューをしてもらうにあたり、どのような理由や目的からコードを変更したのか書いてください-->
今回作成しようとしているLINEbotの基本機能である「位置情報を送信した時に周辺の２次会に適した店舗情報を返す」と言う機能の実装を目的としている。
特に今回は[機能仕様のレベル2](https://giftee.docbase.io/posts/3270615#%E6%A9%9F%E8%83%BD%E4%BB%95%E6%A7%98%E3%83%AC%E3%83%99%E3%83%AB2-%E5%BF%85%E9%A0%88)までの位置情報を使って店舗情報を取得することを目的としている。

## やったこと
<!-- PR 内でやったことを箇条書きにしてください-->
- 位置情報を受け取った時Botのメッセージイベントが発火するようにした
- 上記イベントが発火した時に店舗情報を検索するメソッドを実装
　　- メッセージからの位置情報（緯度、経度）を元に外部API（hotpepper）を叩いた
　　- レスポンスボディーから店名だけを取り出して返す
- メソッドの返り値を返信メッセージとして表示

## キャプチャ

スクリーンショットなどがあれば
<img width="496" alt="スクリーンショット 2024-02-05 15 27 12" src="https://github.com/lCyou/intern-line-bot/assets/87867174/c3d2e9ff-01a5-40e9-bbb2-a11eacfaa95c">

## 補足
これからやること
- [ ] 返信は見やすいようにカルーセルにして返す
- [ ] 返信内容は店名、場所、イメージ画像が理想
- [ ] クレジットの表記
