### PR TITLE
話題提供する機能を追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -38,20 +38,6 @@ class WebhookController < ApplicationController
               "imageSize": "cover"
             }
           }
-          p message
-          client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Location
-          res_text = search_shop(event.message['latitude'], event.message['longitude'])
-          message = {
-            "type": "template",
-            "altText": "おすすめのお店情報が届きました！",
-            "template": {
-              "type": "carousel",
-              "columns": res_text,
-              "imageAspectRatio": "rectangle",
-              "imageSize": "cover"
-            }
-          }
           client.reply_message(event['replyToken'], message)
         end
       end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -55,7 +55,7 @@ class WebhookController < ApplicationController
 
   
   def search_shop(lat, lng)
-    uri = URI.parse(hotpepper_api)
+    uri = URI.parse("http://webservice.recruit.co.jp/hotpepper/gourmet/v1/")
     http = Net::HTTP.new(uri.host, uri.port) 
     # hotpepper apiのパラメータ
     # range 3: 1000m以内
@@ -71,7 +71,7 @@ class WebhookController < ApplicationController
         order: 4,
         format: 'json'
     })
-    # p uri
+
     request = Net::HTTP::Get.new(uri)
     response = http.request(request)
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -24,18 +24,95 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
+          text = "飲み会中の会話に困ったときトークテーマを提供します！\n「話題」とか「トークテーマ」で送ってみてね！"
+          if event.message['text'].include?("題") || event.message['text'].include?("テーマ") then
+            text = combine_word
+          end
           message = {
             type: 'text',
-            text: event.message['text']
+            text: text
           }
           client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
+        when Line::Bot::Event::MessageType::Location
+          res_text = search_shop(event.message['latitude'], event.message['longitude'])
+          message = {
+            "type": "template",
+            "altText": "おすすめのお店情報が届きました！",
+            "template": {
+              "type": "carousel",
+              "columns": res_text,
+              "imageAspectRatio": "rectangle",
+              "imageSize": "cover"
+            }
+          }
+          client.reply_message(event['replyToken'], message)
         end
       end
     }
     head :ok
   end
+
+
+  private
+  hotpepper_api = "http://webservice.recruit.co.jp/hotpepper/gourmet/v1/".freeze
+
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+
+  
+  def search_shop(lat, lng)
+    uri = URI.parse(hotpepper_api)
+    http = Net::HTTP.new(uri.host, uri.port) 
+    # hotpepper apiのパラメータ
+    # range 3: 1000m以内
+    # genre G001:居酒屋, G002:ダイニングバー・バル
+    # budget B002:2001~3000円, B003:3001~4000円
+    uri.query = URI.encode_www_form({
+        key: ENV["API_KEY"],
+        lat: lat,
+        lng: lng,
+        range: 3,
+        genre: "G001,G002",
+        budget: "B002,B003",
+        order: 4,
+        format: 'json'
+    })
+    # p uri
+    request = Net::HTTP::Get.new(uri)
+    response = http.request(request)
+
+    if response.code == '200'
+      data = JSON.parse(response.body)
+      columns = []
+      data["results"]["shop"].each do |shop|
+        content = {
+          thumbnailImageUrl: shop["photo"]["mobile"]["l"],
+          title: shop["name"],
+          text: shop["address"],
+          actions: [{
+            type: "uri",
+            label: "詳細を見る",
+            uri: shop["urls"]["pc"]
+          }]
+        }
+        columns.push(content)
+      end
+      columns
+    else
+      p "リクエストが失敗しました。ステータスコード: #{response.code}"
+    end
+  end
+
+  
+  def combine_word
+    five_w = ["いつ", "どこで", "なぜ", "どのように"]
+    object_word = ["食べ物を", "飲み物を", "スポーツを", "趣味を", "仕事を", "恋愛を", "家族を", "友達を", "学校を", "旅行を"]
+    varb_word = [ "しますか", "見ますか", "聞きますか", "話しますか", "考えますか", "感じますか"]
+    five_w.sample + object_word.sample + varb_word.sample
+  end
+
 end


### PR DESCRIPTION
## 実装の背景・目的
ドキュメントの追加実装部分にある飲み会中の話題を提供してくれる機能の実装を目的としている。

## やったこと
-  テーマ、題といった言葉が含まれる文章を条件分岐する
- 言葉を組み合わせてお題を作成する（文脈が考慮されない）
- 違う言葉が来た時「テーマ」「題」が入ったメッセージを送信するようにした


## キャプチャ

スクリーンショットなどがあれば

## 補足
